### PR TITLE
Implement sequence return values

### DIFF
--- a/programs/server/main.lua
+++ b/programs/server/main.lua
@@ -1,4 +1,11 @@
 server = {}
+server.clients = {}
+
+function server:addClient(client)
+    assert(client, "No client object given")
+    self.clients[client.address] = client
+    print("New client registered: " .. tostring(client.address))
+end
 
 local modem = getComponent("modem")
 

--- a/programs/server/network/client.class
+++ b/programs/server/network/client.class
@@ -1,0 +1,33 @@
+local client = newClass()
+
+function client:constructor(address, protocol)
+    assert(self, "Must be called on a object")
+    assert(address, "No remote address given")
+    assert(protocol, "No protocol given")
+
+    self.address = address
+    self.protocol = protocol
+    self.sessionID = nil
+end
+
+-- Starts the initial handshake with this client
+function client:handshake()
+    if not self.sessionID then
+        -- Start handshake sequence via the protocol
+        local handshakeSeq = nil
+        for id, seq in pairs(self.protocol.sequences) do
+            if seq.name == "handshake" then
+                handshakeSeq = id
+                break
+            end
+        end
+        if handshakeSeq then
+            self.sessionID = self.protocol:startSession(handshakeSeq, self.address)
+        else
+            error("Handshake sequence not available in protocol " .. self.protocol.name)
+        end
+    end
+end
+
+return client
+

--- a/programs/server/network/protocol.class
+++ b/programs/server/network/protocol.class
@@ -53,7 +53,12 @@ function protocol:start()
                 end
 
                 -- Process the message in the session
-                self.sessions[sessionID]:process(message)
+                local status, result = self.sessions[sessionID]:process(message)
+                if status == class("sequence").sequenceStatus.finished then
+                    local sequence = self.sessions[sessionID]
+                    self.sessions[sessionID] = nil
+                    self:onSequenceFinished(sequence, result, sessionID)
+                end
             else
                 error("Unknown message type or sequence ID in protocol " .. self.name)
             end
@@ -94,6 +99,10 @@ end
 function protocol:createMessage(remoteAddress, protocol, distance, ...)
     assert(self, "Must be called on a object")
     return class("/shn-01/network/message"):new(remoteAddress, protocol, distance, ...)
+end
+
+function protocol:onSequenceFinished(sequence, result, sessionID)
+    -- Can be overridden by subclasses to react to finished sequences
 end
 
 return protocol

--- a/programs/server/network/protocols/nerve.class
+++ b/programs/server/network/protocols/nerve.class
@@ -11,4 +11,12 @@ function command:constructor()
 
 end
 
+function command:onSequenceFinished(sequence, result, sessionID)
+    if sequence.name == "handshake" and result then
+        if server and server.addClient then
+            server:addClient(result)
+        end
+    end
+end
+
 return command

--- a/programs/server/network/sequence.class
+++ b/programs/server/network/sequence.class
@@ -48,6 +48,7 @@ function sequence:constructor(name, func, timeout, timeoutCallback)
     self.startTime = os.time()
     self.timeout = timeout or 60 -- Default timeout of 60 seconds
     self.timeoutCallback = timeoutCallback
+    self.result = nil -- Result returned by the sequence when finished
 
 end
 
@@ -73,16 +74,18 @@ function sequence:process(message)
     assert(not self:checkTimeout(), "Sequence has timed out")
     assert(message, "No message given")
 
-    local ok, coSuccess, coMessage = pcall(coroutine.resume, self.routine, message)
-    if not ok then
-        error("Error resuming coroutine in " .. tostring(self) .. ": " .. tostring(coSuccess))
+    local results = {pcall(coroutine.resume, self.routine, message)}
+    if not results[1] then
+        error("Error resuming coroutine in " .. tostring(self) .. ": " .. tostring(results[2]))
     end
-    if not coSuccess then
-        error("Coroutine error in " .. tostring(self) .. ": " .. tostring(coMessage))
+    if not results[2] then
+        error("Coroutine error in " .. tostring(self) .. ": " .. tostring(results[3]))
     end
 
     if coroutine.status(self.routine) == "dead" then
         self.status = sequence.sequenceStatus.finished
+        self.result = {select(3, table.unpack(results))}
+        return self.status, table.unpack(self.result)
     end
     return self.status
 end

--- a/programs/server/network/sequences/handshake/client.class
+++ b/programs/server/network/sequences/handshake/client.class
@@ -1,0 +1,16 @@
+local handshake = newClass(class("../../sequence"))
+
+function handshake:constructor()
+    assert(self, "Must be called on a object")
+    self.base:constructor("handshake",
+        function(message)
+            -- Client-side handshake logic
+            print("Client-side handshake initiated for address:", message.remoteAddress)
+            -- Simulate some processing
+            coroutine.yield("Processing client handshake...")
+            print("Client-side handshake completed")
+        end)
+end
+
+return handshake
+

--- a/programs/server/network/sequences/handshake/server.class
+++ b/programs/server/network/sequences/handshake/server.class
@@ -3,20 +3,19 @@ local handshake = newClass(class("../../sequence"))
 function handshake:constructor()
     assert(self, "Must be called on a object")
     self.base:constructor("handshake",
-    function(sessionID, ...)
-        -- Server-side handshake logic
-        print("Server-side handshake initiated for session ID:", sessionID)
-        -- Simulate some processing
-        coroutine.yield("Processing server handshake...")
-        print("Server-side handshake completed")
-    end, 
-    function(sessionID, ...)
-        -- Client-side handshake logic
-        print("Client-side handshake initiated for session ID:", sessionID)
-        -- Simulate some processing
-        coroutine.yield("Processing client handshake...")
-        print("Client-side handshake completed")
-    end)
+        function(message)
+            -- Server-side handshake logic
+            print("Server-side handshake initiated for address:", message.remoteAddress)
+            -- Simulate some processing
+            coroutine.yield("Processing server handshake...")
+
+            -- Create a client object for this connection
+            local clientClass = class("../../client.class")
+            local client = clientClass:new(message.remoteAddress, message.protocol)
+
+            print("Server-side handshake completed")
+            return client
+        end)
 end
 
 return handshake


### PR DESCRIPTION
## Summary
- allow network sequences to return results
- use sequence results inside protocols
- register handshake clients through `nerve` protocol

## Testing
- ❌ `lua -v`

------
https://chatgpt.com/codex/tasks/task_e_684e07b2920c8330b68f2a4693aeff44